### PR TITLE
[stable/sealed-secrets] Upgraded to 0.8.2 and added RBAC rules for self service cert.pem for …

### DIFF
--- a/stable/sealed-secrets/Chart.yaml
+++ b/stable/sealed-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 name: sealed-secrets
 description: A Helm chart for Sealed Secrets
-version: 1.4.0
-appVersion: 0.8.1
+version: 1.4.1
+appVersion: 0.8.2
 kubeVersion: ">=1.9.0-0"
 home: https://github.com/bitnami-labs/sealed-secrets
 apiVersion: v1

--- a/stable/sealed-secrets/templates/role-binding.yaml
+++ b/stable/sealed-secrets/templates/role-binding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "sealed-secrets.fullname" . }}
+  name: {{ template "sealed-secrets.fullname" . }}-key-admin
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}
@@ -12,10 +12,29 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: sealed-secrets-key-admin
+  name: {{ template "sealed-secrets.fullname" . }}-key-admin
 subjects:
   - apiGroup: ""
     kind: ServiceAccount
     name: {{ template "sealed-secrets.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
 {{ end }}

--- a/stable/sealed-secrets/templates/role.yaml
+++ b/stable/sealed-secrets/templates/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: sealed-secrets-key-admin
+  name: {{ template "sealed-secrets.fullname" . }}-key-admin
   labels:
     app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
     helm.sh/chart: {{ template "sealed-secrets.chart" . }}
@@ -25,4 +25,25 @@ rules:
     verbs:
       - create
       - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "sealed-secrets.fullname" . }}-service-proxier
+  labels:
+    app.kubernetes.io/name: {{ template "sealed-secrets.name" . }}
+    helm.sh/chart: {{ template "sealed-secrets.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - 'http:{{ template "sealed-secrets.fullname" . }}:'
+  - {{ template "sealed-secrets.fullname" . }}
+  resources:
+  - services/proxy
+  verbs:
+  - get
 {{ end }}

--- a/stable/sealed-secrets/values.yaml
+++ b/stable/sealed-secrets/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: quay.io/bitnami/sealed-secrets-controller
-  tag: v0.8.1
+  tag: v0.8.2
   pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
…all authenticated users

Signed-off-by: Albert Asawaroengchai <ateerakarna@gmail.com>

#### What this PR does / why we need it:

Upgrades image to 0.8.2 and implements RBAC to allow all authenticated users to get the public key.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
